### PR TITLE
fix: add help summaries to env list and env display

### DIFF
--- a/src/commands/env/display.ts
+++ b/src/commands/env/display.ts
@@ -13,6 +13,7 @@ Messages.importMessagesDirectory(__dirname);
 const messages = Messages.loadMessages('@salesforce/plugin-env', 'display');
 
 export default class EnvDisplay extends Command {
+  public static readonly summary = messages.getMessage('summary');
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static flags = {

--- a/src/commands/env/list.ts
+++ b/src/commands/env/list.ts
@@ -16,6 +16,7 @@ const messages = Messages.loadMessages('@salesforce/plugin-env', 'list');
 export type SfOrgs = SfOrg[];
 
 export default class EnvList extends Command {
+  public static readonly summary = messages.getMessage('summary');
   public static readonly description = messages.getMessage('description');
   public static readonly examples = messages.getMessages('examples');
   public static flags = {


### PR DESCRIPTION
### What does this PR do?
Adds summaries to the help output for the `env list` and `env display` commands

### What issues does this PR fix or reference?
@W-9608872@
