### PR TITLE
fix: hide extended flag from help

### DIFF
--- a/src/commands/env/list.ts
+++ b/src/commands/env/list.ts
@@ -22,6 +22,7 @@ export default class EnvList extends Command {
     extended: Flags.boolean({
       char: 'x',
       summary: messages.getMessage('flags.extended.summary'),
+      hidden: true,
     }),
     columns: Flags.string({
       summary: messages.getMessage('flags.columns.summary'),


### PR DESCRIPTION
### What does this PR do?
Set hidden attribute to true for extended flag, which removes it from help.

### What issues does this PR fix or reference?
@W-9642544@
