### PR TITLE
fix: no found envs

### DIFF
--- a/src/commands/env/display.ts
+++ b/src/commands/env/display.ts
@@ -36,7 +36,7 @@ export default class EnvDisplay extends SfCommand<JsonObject> {
 
     try {
       const results = await SfHook.run(this.config, 'sf:env:display', { targetEnv });
-      const result = results.successes.find((s) => !!s.result)?.result || null;
+      const result = results.successes.find((s) => !!s.result?.data)?.result || null;
 
       if (!result) {
         throw messages.createError('error.NoEnvFound', [targetEnv]);


### PR DESCRIPTION
### What does this PR do?

Properly search for truthy results from `sf:env:display` hook. Doing so prevents `TypeError: Cannot convert undefined or null to object` from being thrown.

### What issues does this PR fix or reference?
@W-9972563@